### PR TITLE
Add standalone package type definitions

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,6 +19,9 @@
 !src/**/*.js
 !src/**/*.js.map
 
+# Whitelist - typings/
+!typings/**/*.d.ts
+
 # Blacklist - (normal behavior) these will override any whitelist
 *.test.ts
 *.test.d.ts

--- a/definitions.d.ts
+++ b/definitions.d.ts
@@ -1,1 +1,0 @@
-declare module 'postcss-value-parser';

--- a/fixtures/typings-test/tsconfig.json
+++ b/fixtures/typings-test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "es2017",
+        "module": "commonjs",
+        "noEmit": true
+    },
+    "types": ["xterm"],
+    "files": [
+        "typings-test.ts"
+    ]
+}
+

--- a/fixtures/typings-test/typings-test.ts
+++ b/fixtures/typings-test/typings-test.ts
@@ -1,0 +1,10 @@
+/// <reference path="../../typings/xterm-ligature-support.d.ts" />
+
+import { Terminal } from 'xterm';
+import * as ligatures from 'xterm-ligature-support';
+
+Terminal.applyAddon(ligatures);
+ligatures.apply(Terminal);
+
+const terminal = new Terminal();
+ligatures.enableLigatures(terminal);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">8.0.0"
   },
   "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "types": "typings/xterm-ligature-support.d.ts",
   "scripts": {
     "prepare": "node bin/download-fonts.js",
     "lint": "tslint --project tsconfig.json --fix",
@@ -22,7 +22,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "pretest": "npm run build",
-    "test": "nyc mocha lib/**/*.test.js"
+    "test": "nyc mocha lib/**/*.{test,integration}.js"
   },
   "keywords": [
     "font",

--- a/src/index.integration.ts
+++ b/src/index.integration.ts
@@ -1,0 +1,11 @@
+import * as cp from 'child_process';
+import * as path from 'path';
+import { assert } from 'chai';
+
+describe('typings', () => {
+  it('compiles successfully', function (): void {
+    this.timeout(10000);
+    const result = cp.spawnSync('tsc', { cwd: path.resolve('./fixtures/typings-test')});
+    assert.equal(result.status, 0, `build did not succeed:\nstdout: ${result.stdout.toString()}\nstderr: ${result.stderr.toString()}\n`);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,13 @@ export function enableLigatures(term: Terminal): void {
   });
 }
 
+/**
+ * Add capabilities to the provided terminal class for enabling ligature
+ * support. After calling this function, an `enableLigatures()` method is
+ * available on the terminal class, which will enable ligature support when
+ * called.
+ * @param terminalConstructor Terminal class from xterm.js
+ */
 export function apply(terminalConstructor: typeof Terminal): void {
   (<any>terminalConstructor.prototype).enableLigatures = function (): void {
     enableLigatures(this);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "target": "es2017",
         "module": "commonjs",
-        "declaration": true,
         "sourceMap": true,
         "outDir": "lib",
         "rootDir": "src",
@@ -11,7 +10,6 @@
         "preserveWatchOutput": true
     },
     "include": [
-        "src",
-        "definitions.d.ts"
+        "src"
     ]
 }

--- a/typings/xterm-ligature-support.d.ts
+++ b/typings/xterm-ligature-support.d.ts
@@ -1,0 +1,30 @@
+/**
+ * @license MIT
+ *
+ * This contains the type declarations for the xterm-ligature-support library.
+ * Note that some interfaces may differ between this file and the actual
+ * implementation in src/, that's because this file declares the *public* API
+ * which is intended to be stable and consumed by external programs.
+ */
+
+declare module 'xterm-ligature-support' {
+  import { Terminal } from 'xterm';
+
+  /**
+   * Add capabilities to the provided terminal class for enabling ligature
+   * support. After calling this function, an `enableLigatures()` method is
+   * available on the terminal class, which will enable ligature support when
+   * called.
+   * @param terminalConstructor Terminal class from xterm.js
+   */
+  export function apply(terminalConstructor: typeof Terminal): void;
+
+  /**
+   * Enable ligature support for the provided Terminal instance. To function
+   * properly, this must be called after `open()` is called on the therminal. If
+   * the font currently in use supports ligatures, the terminal will
+   * automatically start to render them.
+   * @param term Terminal instance from xterm.js
+   */
+  export function enableLigatures(term: Terminal): void;
+}


### PR DESCRIPTION
Fixes #3 by adding a `typings/xterm-ligature-support.d.ts` file with the public interface of the package. With this change, typescript will no longer output its own declaration files.